### PR TITLE
add docsify-sidebar-collapse plugin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
   
   <link rel="icon" href="https://cdn.jsdelivr.net/gh/looly/hutool-site/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css" />
   
   <!-- 百度统计 -->
   <script>
@@ -86,6 +87,7 @@
   <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/emoji.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
 
   <script>
       ((window.gitter = {}).chat = {}).options = {


### PR DESCRIPTION
侧边栏目录支持折叠，效果见：[https://bytesfly.github.io/hutool-site/](https://bytesfly.github.io/hutool-site/) , 插件源码：[https://github.com/iPeng6/docsify-sidebar-collapse](https://github.com/iPeng6/docsify-sidebar-collapse)，从官方插件中 [https://docsify.js.org/#/awesome?id=plugins](https://docsify.js.org/#/awesome?id=plugins) 也能找到 `docsify-sidebar-collapse`