### PR TITLE
docs:fix(extra/模板引擎): 修复模板引擎封装文中的示例代码路径错误

### DIFF
--- a/docs/extra/模板引擎/模板引擎封装-TemplateUtil.md
+++ b/docs/extra/模板引擎/模板引擎封装-TemplateUtil.md
@@ -43,7 +43,7 @@ String result = template.render(Dict.create().set("name", "Hutool"));
 
 ```java
 TemplateEngine engine = TemplateUtil.createEngine(new TemplateConfig("templates", ResourceMode.CLASSPATH));
-Template template = engine.getTemplate("templates/velocity_test.vtl");
+Template template = engine.getTemplate("velocity_test.vtl");
 String result = template.render(Dict.create().set("name", "Hutool"));
 ```
 


### PR DESCRIPTION
- 修复从classpath查找模板渲染一节 示例代码中模板文件找不到的问题